### PR TITLE
Simplify TableModel type handling

### DIFF
--- a/src/main/java/com/github/minecraftschurlimods/bibliocraft/client/model/TableModel.java
+++ b/src/main/java/com/github/minecraftschurlimods/bibliocraft/client/model/TableModel.java
@@ -1,7 +1,6 @@
 package com.github.minecraftschurlimods.bibliocraft.client.model;
 
 import com.github.minecraftschurlimods.bibliocraft.content.table.TableBlock;
-import com.github.minecraftschurlimods.bibliocraft.content.table.TableBlockEntity;
 import com.github.minecraftschurlimods.bibliocraft.util.BCUtil;
 import com.google.gson.JsonObject;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -54,7 +53,10 @@ public class TableModel extends DynamicBlockModel {
 
     @Override
     public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, RandomSource rand, ModelData extraData, @Nullable RenderType renderType) {
-        TableBlock.Type type = extraData.get(TableBlockEntity.TYPE_PROPERTY);
+        TableBlock.Type type = TableBlock.Type.NONE;
+        if (state != null && state.hasProperty(TableBlock.TYPE)) {
+            type = state.getValue(TableBlock.TYPE);
+        }
         return new ArrayList<>(baseMap.get(type).getQuads(state, side, rand, extraData, renderType));
     }
 

--- a/src/main/java/com/github/minecraftschurlimods/bibliocraft/client/model/TableModel.java
+++ b/src/main/java/com/github/minecraftschurlimods/bibliocraft/client/model/TableModel.java
@@ -30,7 +30,6 @@ import net.neoforged.neoforge.client.model.geometry.IUnbakedGeometry;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,7 @@ public class TableModel extends DynamicBlockModel {
         if (state != null && state.hasProperty(TableBlock.TYPE)) {
             type = state.getValue(TableBlock.TYPE);
         }
-        return new ArrayList<>(baseMap.get(type).getQuads(state, side, rand, extraData, renderType));
+        return baseMap.get(type).getQuads(state, side, rand, extraData, renderType);
     }
 
     @Override

--- a/src/main/java/com/github/minecraftschurlimods/bibliocraft/content/table/TableBlockEntity.java
+++ b/src/main/java/com/github/minecraftschurlimods/bibliocraft/content/table/TableBlockEntity.java
@@ -10,14 +10,10 @@ import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.client.model.data.ModelData;
-import net.neoforged.neoforge.client.model.data.ModelProperty;
 
 import java.util.Objects;
 
 public class TableBlockEntity extends BCBlockEntity {
-    public static final ModelProperty<TableBlock.Type> TYPE_PROPERTY = new ModelProperty<>();
-
     public TableBlockEntity(BlockPos pos, BlockState state) {
         super(BCBlockEntities.TABLE.get(), 2, pos, state);
     }
@@ -41,10 +37,5 @@ public class TableBlockEntity extends BCBlockEntity {
         if (slot == 1) {
             requestModelDataUpdate();
         }
-    }
-
-    @Override
-    public ModelData getModelData() {
-        return ModelData.builder().with(TYPE_PROPERTY, getBlockState().getValue(TableBlock.TYPE)).build();
     }
 }


### PR DESCRIPTION
This PR makes some minor optimizations to the table model. Since the table type is already available in the provided block state, it is unnecessary to go through the overhead of `ModelData` to compute/retrieve it. It's also unnecessary to defensively copy the quad list of the inner model, since quad lists are considered immutable by convention, and no extra quads are added here (unlike the bookcase model).

(This also fixes the table model crashing when `ModelData.EMPTY` is provided.)