### PR TITLE
fix printing table clone cost not updating

### DIFF
--- a/src/main/java/com/github/minecraftschurlimods/bibliocraft/content/printingtable/PrintingTableBlockEntity.java
+++ b/src/main/java/com/github/minecraftschurlimods/bibliocraft/content/printingtable/PrintingTableBlockEntity.java
@@ -114,9 +114,13 @@ public class PrintingTableBlockEntity extends BCMenuBlockEntity implements HasTo
         if (isSlotDisabled(slot) && !stack.isEmpty()) {
             setSlotDisabled(slot, false);
         }
+
+        ItemStack old = getItem(slot).copy();
         super.setItem(slot, stack);
         recipeInput = null;
-        if (recipe == null || !recipe.matches(getRecipeInput(), BCUtil.nonNull(getLevel()))) {
+        
+        boolean changed = !ItemStack.isSameItemSameComponents(old, stack);
+        if (changed || recipe == null || !recipe.matches(getRecipeInput(), BCUtil.nonNull(getLevel()))) {
             calculateRecipe(false);
             setChanged();
         }


### PR DESCRIPTION
When in clone mode, swapping the book without emptying the slot doesn't update the cost, added check for if any components of the item are changed.